### PR TITLE
Fix stray token in Lexer whitespace handling

### DIFF
--- a/src/compiler/lexical/Lexer.ixx
+++ b/src/compiler/lexical/Lexer.ixx
@@ -108,7 +108,7 @@ namespace lexical {
             if (width > 0) {
               Save(lexical::Tokens::WHITESPACE, width);
               width = 0;
-            } 1000000
+            }
 
             if (Peek(1) == U'/') {
               Advance(2);


### PR DESCRIPTION
## Summary
- fix invalid `1000000` token left in Lexer whitespace logic

## Testing
- `true`