### PR TITLE
Fix do keyword contradiction

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2451,7 +2451,7 @@ Warble emphasizes minimalism; most language functionality is implemented as iden
 * **`else`** — Provides an alternative branch in a conditional statement.
 * **`for`** — Begins a looping construct over an iterable.
 * **`while`** — Begins a loop construct based on a boolean condition.
-* **`do`** — Begins a do-while style loop construct.
+* **`do`** — Introduces a scoped block, or starts the `do` section of a `do ... while` loop.
 
 #### Pattern Matching and Constraints
 


### PR DESCRIPTION
## Summary
- clarify that `do` is used for both scoped blocks and `do ... while` loops

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a759d55883208943aaecdfe5afe7