### PR TITLE
Add await to reserved keywords

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2452,6 +2452,7 @@ Warble emphasizes minimalism; most language functionality is implemented as iden
 * **`for`** — Begins a looping construct over an iterable.
 * **`while`** — Begins a loop construct based on a boolean condition.
 * **`do`** — Introduces a scoped block, or starts the `do` section of a `do ... while` loop.
+* **`await`** — Unary prefix operator that suspends the current thread until a promise resolves, repeatedly returning to the work queue between checks.
 
 #### Pattern Matching and Constraints
 


### PR DESCRIPTION
## Summary
- document the `await` keyword as a reserved word in the spec

## Testing
- `grep -n await -n docs/spec.md`

------
https://chatgpt.com/codex/tasks/task_e_6840d4aead7c8320b47908e57871456c